### PR TITLE
Resolve theme toggle OS preference bug and improve accessibility (#271)

### DIFF
--- a/_includes/theme_toggle.html
+++ b/_includes/theme_toggle.html
@@ -1,4 +1,4 @@
-<button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">
+<button class="theme-toggle" id="theme-toggle" aria-pressed="false" aria-label="Switch to dark theme" title="Switch to dark theme">
   <svg id="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
     <path d="M12 18a6 6 0 1 1 0-12 6 6 0 0 1 0 12zm0-2a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM11 1h2v3h-2V1zm0 19h2v3h-2v-3zM3.515 4.929l1.414-1.414L7.05 5.636 5.636 7.05 3.515 4.93zM16.95 18.364l1.414-1.414 2.121 2.121-1.414 1.414-2.121-2.121zm2.121-14.85l1.414 1.415-2.121 2.121-1.414-1.414 2.121-2.121zM5.636 16.95l1.414 1.414-2.121 2.121-1.414-1.414 2.121-2.121zM23 11v2h-3v-2h3zM4 11v2H1v-2h3z"/>
   </svg>
@@ -24,8 +24,12 @@
       return 'light';
     };
 
-    const setTheme = (theme) => {
-      if (theme === 'dark') {
+    // Added a saveToStorage parameter (defaults to false)
+    const setTheme = (theme, saveToStorage = false) => {
+      const isDark = theme === 'dark';
+      const themeToggle = document.getElementById('theme-toggle');
+
+      if (isDark) {
         document.documentElement.setAttribute('data-theme', 'dark');
         document.getElementById('sun-icon').style.display = 'none';
         document.getElementById('moon-icon').style.display = 'block';
@@ -34,12 +38,23 @@
         document.getElementById('sun-icon').style.display = 'block';
         document.getElementById('moon-icon').style.display = 'none';
       }
-      localStorage.setItem('theme', theme);
+
+      // 1. Accessibility (ARIA) Update
+      if (themeToggle) {
+        themeToggle.setAttribute('aria-pressed', isDark);
+        themeToggle.setAttribute('aria-label', `Switch to ${isDark ? 'light' : 'dark'} theme`);
+        themeToggle.setAttribute('title', `Switch to ${isDark ? 'light' : 'dark'} theme`);
+      }
+
+      // 2. Storage Fix: Only write to localStorage when explicitly instructed
+      if (saveToStorage) {
+        localStorage.setItem('theme', theme);
+      }
 
       // Update Giscus theme if it exists
       const giscusFrame = document.querySelector('iframe.giscus-frame');
       if (giscusFrame) {
-        const giscusTheme = theme === 'dark' ? 'dark' : 'light';
+        const giscusTheme = isDark ? 'dark' : 'light';
         giscusFrame.contentWindow.postMessage(
           { giscus: { setConfig: { theme: giscusTheme } } },
           'https://giscus.app'
@@ -48,17 +63,22 @@
     };
 
     // Set initial theme immediately to prevent flash
+    // We pass `false` here so we DO NOT write the OS preference to localStorage
     const currentTheme = getInitialTheme();
-    setTheme(currentTheme);
+    setTheme(currentTheme, false);
 
     // Add event listener when DOM is ready
     document.addEventListener('DOMContentLoaded', function() {
       const themeToggle = document.getElementById('theme-toggle');
 
       themeToggle.addEventListener('click', function() {
-        const currentTheme = localStorage.getItem('theme') || 'light';
-        const newTheme = currentTheme === 'light' ? 'dark' : 'light';
-        setTheme(newTheme);
+        // Read current state from DOM rather than storage. 
+        // If the user's OS is dark, storage is empty, so relying on storage defaults to 'light', causing a bug where the first click does nothing.
+        const currentActiveTheme = document.documentElement.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
+        const newTheme = currentActiveTheme === 'light' ? 'dark' : 'light';
+        
+        // Pass `true` here because the user explicitly clicked the button!
+        setTheme(newTheme, true);
 
         // Track theme toggle
         if (window.UmamiTracker) {
@@ -69,8 +89,9 @@
       // Listen for system theme changes
       if (window.matchMedia) {
         window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function(e) {
+          // Because initial load no longer writes to localStorage, this check will now work properly.
           if (!localStorage.getItem('theme')) {
-            setTheme(e.matches ? 'dark' : 'light');
+            setTheme(e.matches ? 'dark' : 'light', false);
           }
         });
       }

--- a/assets/css/overrides.css
+++ b/assets/css/overrides.css
@@ -2237,7 +2237,21 @@ small {
   outline: 2px solid var(--accent-color);
   outline-offset: 2px;
 }
+/* --- Theme Toggle Accessibility Focus (#271) --- */
+.theme-toggle:focus {
+  outline: 2px solid var(--accent-color);
+  outline-offset: 2px;
+}
 
+.theme-toggle:focus:not(:focus-visible) {
+  outline: none;
+}
+
+.theme-toggle:focus-visible {
+  outline: 2px solid var(--accent-color);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
 /* --- Hamburger Icon Lines --- */
 .hamburger-menu .hamburger-line {
   background: var(--text-primary) !important;

--- a/assets/css/overrides.css
+++ b/assets/css/overrides.css
@@ -2237,6 +2237,7 @@ small {
   outline: 2px solid var(--accent-color);
   outline-offset: 2px;
 }
+
 /* --- Theme Toggle Accessibility Focus (#271) --- */
 .theme-toggle:focus {
   outline: 2px solid var(--accent-color);


### PR DESCRIPTION
Resolves #271.

**Changes made:**
* **Storage Fix:** Modified `setTheme` to only persist to `localStorage` on explicit user click, allowing the initial page load to safely respect the OS `matchMedia` preference.
* **Screen Reader A11y:** Added dynamic `aria-pressed`, `aria-label`, and `title` updates to the toggle button.
* **Keyboard A11y:** Added `.theme-toggle:focus-visible` rules in `overrides.css` to match the existing hamburger menu focus styling.